### PR TITLE
pushトリガーをCodeQL、Gitleaks、Semgrepワークフローに追加

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "package*.json", "tsconfig*.json"]
+  push:
+    branches: [main, develop]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,6 +1,8 @@
 name: Gitleaks (SARIF)
 on:
   pull_request:
+  push:
+    branches: [main, develop]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", ".github/workflows/**"]
+  push:
+    branches: [main, develop]
   workflow_dispatch: # 手動実行できるようにする
 
 permissions:


### PR DESCRIPTION
このプルリクエストは、GitHub Actionsのワークフローの設定を更新し、プルリクエストや手動実行に加え、`main`および`develop`ブランチへのプッシュ時にもセキュリティチェックとコード分析チェックがトリガーされるようにします。

**ワークフローのトリガー機能の強化:**

* `.github/workflows/codeql.yml` ワークフローに `main` と `develop` ブランチの `push` トリガーを追加し、直接プッシュ時に CodeQL 分析を実行するようにしました。
* `.github/workflows/gitleaks.yml` ワークフローに `main` と `develop` ブランチの `push` トリガーを追加し、直接プッシュ時に Gitleaks チェックを実行するようにしました。
* `.github/workflows/semgrep.yml` ワークフローの `main` と `develop` ブランチに `push` トリガーを追加し、直接プッシュ時に Semgrep 分析を実行するようにしました。