### PR TITLE
fix: ステージング環境のS3バケット名を修正

### DIFF
--- a/infra/env/stage/backend.tf
+++ b/infra/env/stage/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "summary-training-tf-state-stage"
+    bucket         = "summary-training-tf-state-stg"
     key            = "terraform/state/default.tfstate" # 状態ファイルの保存パス
     region         = "ap-northeast-1"
     encrypt        = true                             # サーバーサイド暗号化を有効


### PR DESCRIPTION
このプルリクエストには、ステージング環境のTerraformバックエンド構成の軽微な更新が含まれています。Terraform状態ファイルの保存に使用されるS3バケット名は、より短い標準化されたサフィックスを使用するように変更されました。

* `infra/env/stage/backend.tf` 内の S3 バックエンド バケット名を、一貫性と標準化のため `summary-training-tf-state-stage` から `summary-training-tf-state-stg` に変更しました。