### PR TITLE
ステージング環境のS3バックエンド構成の軽微な更新

### DIFF
--- a/infra/env/stage/backend.tf
+++ b/infra/env/stage/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "summary-training-tf-state-stage"
+    bucket         = "summary-training-tf-state-stg"
     key            = "terraform/state/default.tfstate" # 状態ファイルの保存パス
     region         = "ap-northeast-1"
     encrypt        = true                             # サーバーサイド暗号化を有効

--- a/infra/env/stage/main.tf
+++ b/infra/env/stage/main.tf
@@ -1,0 +1,10 @@
+# 以下リソース定義をコメントアウトするとtf.stateには存在するが定義がないのでdestroy処理が走るので注意
+# 監視から除外したい場合は、terraform state rm リソース名
+
+# 初期設定時、GitHub OIDCを信頼するIRMロールの作成
+module "iam" {
+  source          = "../../modules/iam"
+  github_owner    = "muratariku0903"
+  github_repo     = "summary-training"
+  tf_state_bucket = "summary-training-tf-state-stg"
+}

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -22,7 +22,10 @@ resource "aws_iam_role" "github_actions_role" {
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
           StringLike = {
-            "token.actions.githubusercontent.com:sub" = "repo:${var.github_owner}/${var.github_repo}:ref:refs/heads/*"
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:${var.github_owner}/${var.github_repo}:ref:refs/heads/*",
+              "repo:${var.github_owner}/${var.github_repo}:pull_request",
+            ],
           }
         }
       }


### PR DESCRIPTION
このプルリクエストには、ステージング環境のS3バックエンド構成の軽微な更新が含まれています。`backend.tf`内のS3バケット名は、標準化された命名規則に準拠するように変更されました。

* `infra/env/stage/backend.tf`内の`bucket`値を、命名規則に準拠させるため、`summary-training-tf-state-stage`から`summary-training-tf-state-stg`に変更しました。