### PR TITLE
GitHub Actionsのデプロイメント向けに環境固有のIAMロールとポリシーをサポートするようにインフラストラクチャコードを更新

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Configure AWS Credentials # Github ActionsのAWS認証
         uses: aws-actions/configure-aws-credentials@v2 # GitHub公式のAWS認証アクション を使う（OIDC経由の認証）
         with:
-          role-to-assume: arn:aws:iam::${{secrets.TF_AWS_ACCOUNT_ID}}:role/GitHubActionsTerraformRole
+          role-to-assume: arn:aws:iam::${{secrets.TF_AWS_ACCOUNT_ID}}:role/GitHubActionsTerraformRole-${{env.ENVIRONMENT}}
           role-session-name: GitHubActionsTerraformSession
           aws-region: ap-northeast-1
 

--- a/infra/env/dev/main.tf
+++ b/infra/env/dev/main.tf
@@ -3,6 +3,7 @@
 
 # 初期設定時、GitHub OIDCを信頼するIRMロールの作成
 module "iam" {
+  env             = "dev"
   source          = "../../modules/iam"
   github_owner    = "muratariku0903"
   github_repo     = "summary-training"

--- a/infra/env/stage/main.tf
+++ b/infra/env/stage/main.tf
@@ -3,6 +3,7 @@
 
 # 初期設定時、GitHub OIDCを信頼するIRMロールの作成
 module "iam" {
+  env             = "stage"
   source          = "../../modules/iam"
   github_owner    = "muratariku0903"
   github_repo     = "summary-training"

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -4,7 +4,7 @@ data "aws_caller_identity" "current" {}
 # GitHub OIDCを信頼するIRMロール↓
 # Github　Actionsがこのロールを引き受ける。
 resource "aws_iam_role" "github_actions_role" {
-  name = "GitHubActionsTerraformRole"
+  name = "GitHubActionsTerraformRole-${var.env}"
 
   # GitHubのOIDCプロバイダを信頼
   # 前提としてAWSでは、信頼ポリシーを使ってロールを引き受ける主体を指定する　
@@ -36,7 +36,7 @@ resource "aws_iam_role" "github_actions_role" {
 # IAMポリシー（Terraformの実行に必要な最小限の権限）
 # ポリシーを変更した際は、手動でAWSのロールに反映させる、その上で、Github ActionsのPipelineが正常に動作可能
 resource "aws_iam_policy" "terraform_policy" {
-  name        = "GitHubActionsTerraformPolicy"
+  name        = "GitHubActionsTerraformPolicy-${var.env}"
   description = "Least privilege policy for GitHub Actions running Terraform"
 
   policy = jsonencode({
@@ -52,6 +52,8 @@ resource "aws_iam_policy" "terraform_policy" {
           "iam:ListRolePolicies",
           "iam:ListAttachedRolePolicies",
           "iam:ListPolicyVersions",
+          "iam:CreateRole action",
+          "iam:CreatePolicy",
           "sts:GetCallerIdentity",
           "s3:ListBucket",
           "s3:GetObject",

--- a/infra/modules/iam/variables.tf
+++ b/infra/modules/iam/variables.tf
@@ -1,3 +1,8 @@
+variable "env" {
+  description = "env"
+  type        = string
+}
+
 variable "github_owner" {
   description = "Github Owner"
   type        = string


### PR DESCRIPTION
このプルリクエストは、GitHub Actionsのデプロイメント向けに環境固有のIAMロールとポリシーをサポートするようにインフラストラクチャコードを更新します。主な目的は、異なる環境（例：開発環境とステージング環境）ごとに独立したIAMリソースを許可し、セキュリティと管理性を向上させることです。

**環境固有のIAM設定:**

* `infra/modules/iam/main.tf`内のIAMロールとポリシーの名前を、`env`変数を使用して環境名を含めるように変更し、各環境ごとに一意のリソースを確保しました。[[1]](diffhunk://#diff-248f42e9b01a2d5e23f8527b22a80bb65429f71481d6a32bb837eea0c609044aL7-R7) [[2]](diffhunk://# diff-248f42e9b01a2d5e23f8527b22a80bb65429f71481d6a32bb837eea0c609044aL39-R39)
* `infra/modules/iam/variables.tf` ファイルに `env` 変数を追加し、`infra/env/dev/main.tf` と `infra/env/stage/main.tf` の両方から渡すようにしました。これにより、各環境モジュールは独自の環境固有の値で構成されます。[[1]](diffhunk://#diff-c46d1250559a9453cc32d5a116f6e2ac2d1847477865c2425ca50baf775e837bR1-R5) [[2]](diffhunk://# diff-c0c09669f2b6fe0f9764ad74dd5192e61dd51dff4e555d8349d915a13286ec1eR6) [[3]](diffhunk://# diff-4114bf0f043eece6a1e1d8c7bcaa1b746ca926ea618332b707d4b25d5e781161R6)
* IAM ポリシーを更新し、追加の権限 `iam:CreateRole action` および `iam:CreatePolicy` を追加しました。これらの権限は、特定の Terraform 操作に必要です。

**GitHub Actions ワークフローの更新:**

* `.github/workflows/deployment.yml` 内の `role-to-assume` を変更し、環境固有の IAM ロールを使用するようにしました。これにより、デプロイメントは各環境で適切なロールを使用するようになります。