### PR TITLE
ログインフローにおける多要素認証（MFA）の強制適用を導入

### DIFF
--- a/frontend/src/app/(auth)/mfa-verify/page.tsx
+++ b/frontend/src/app/(auth)/mfa-verify/page.tsx
@@ -1,0 +1,40 @@
+import Header from '@/components/layouts/header/Header'
+import { getUserProfile } from '../../../lib/features/user'
+import Main from '@/components/layouts/main/Main'
+import Footer from '@/components/layouts/footer/Footer'
+import MfaSwitcher from '@/components/features/auth/MfaSwitcher'
+import { convertMfaFactors } from '@/lib/supabase/auth/mfa'
+
+export default async function MfaVerifyPage() {
+  // SSRでユーザー情報を取得
+  const { user } = await getUserProfile()
+
+  const mfaFactors = convertMfaFactors({
+    all: [],
+    totp: user.factors?.filter((f) => f.factor_type === 'totp') ?? [],
+    phone: user.factors?.filter((f) => f.factor_type === 'phone') ?? [],
+  })
+
+  return (
+    <>
+      <Header />
+      <Main>
+        <div>
+          <div style={{ maxWidth: 500, margin: '1rem auto', textAlign: 'center' }}>
+            <h2>追加認証が必要です</h2>
+            <p>
+              このアカウントは二段階認証が設定されているため、
+              <br />
+              セキュリティ確保のため認証アプリのコードを入力してください。
+            </p>
+          </div>
+          <MfaSwitcher
+            initSelectedMFA={mfaFactors.length === 1 ? mfaFactors[0] : null}
+            selectableMFAList={mfaFactors}
+          />
+        </div>
+      </Main>
+      <Footer />
+    </>
+  )
+}

--- a/frontend/src/app/api/auth/callback/route.ts
+++ b/frontend/src/app/api/auth/callback/route.ts
@@ -1,9 +1,10 @@
 // app/api/auth/callback/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/client/serverComponentClient'
-import { PUBLIC_PATHS } from '@/lib/constants/routes'
+import { PROTECTED_PATHS, PUBLIC_PATHS } from '@/lib/constants/routes'
 
 // 認可コードとセッション情報を交換する中間エンドポイント
+// OAuth認証後にリダイレクトされる想定
 export async function GET(req: NextRequest) {
   const url = new URL(req.url)
   const code = url.searchParams.get('code')
@@ -11,11 +12,16 @@ export async function GET(req: NextRequest) {
 
   if (code) {
     const supabase = await createClient()
-    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
     if (error) {
       console.error('PKCE code exchange failed:', error.message)
       // 適宜エラーページへリダイレクト
       return NextResponse.redirect(new URL('/auth/error', url).toString())
+    }
+    // ユーザーがMFA設定済みの場合はログイン画面にリダイレクトし、MFAの認証をしてもらう
+    const verifiedFactors = data.user?.factors?.filter((f) => f.status === 'verified')
+    if (verifiedFactors && verifiedFactors?.length > 0) {
+      return NextResponse.redirect(new URL(PROTECTED_PATHS.MFA_VERIFY, url).toString())
     }
   }
 

--- a/frontend/src/lib/constants/routes.ts
+++ b/frontend/src/lib/constants/routes.ts
@@ -15,6 +15,7 @@ export const PROTECTED_PATHS = {
   PASSWORD_CHANGE: '/profile/password-change',
   EMAIL_CHANGE: '/profile/email-change',
   EMAIL_CHANGE_CALLBACK: '/profile/email-change-callback',
+  MFA_VERIFY: '/mfa-verify',
 } as const
 
 /**

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -10,6 +10,7 @@ import dayjs from 'dayjs'
 import { deleteTokenFromCookie } from './lib/api/utils'
 import { checkValidSessionLevel } from './lib/supabase/auth/server'
 import { sanitizeLog } from './utils/log'
+import { Session, SupabaseClient } from '@supabase/supabase-js'
 
 /**
  * Next.js ミドルウェア
@@ -47,18 +48,12 @@ export async function middleware(req: NextRequest) {
 
     // ユーザー情報を取得して、MFA設定をしてるユーザーであればセッションレベルがAAL2であるかチェック
     // AAL2でない場合はセッション情報を破棄してサインイン画面へリダイレクト
-    const { data: user, error: getUserError } =
-      await supabaseMiddlerWareClient.auth.getUser(session.access_token)
-    if (getUserError) {
-      console.warn('fail get user:', getUserError)
-    }
-    if (user.user) {
-      const { valid } = await checkValidSessionLevel(user.user, supabaseMiddlerWareClient)
-      if (!valid) {
-        const signinUrl = req.nextUrl.clone()
-        signinUrl.pathname = PUBLIC_PATHS.SIGNIN
-        return await deleteTokenFromCookie(NextResponse.redirect(signinUrl))
-      }
+    // ただし、PROTECTED_PATHS.MFA_VERIFYは除く（OAuth認証後追加で、MFA認証が必要な場合に遷移させるため）
+    const validSession = await hasValidSession(supabaseMiddlerWareClient, session)
+    if (!validSession && pathname !== PROTECTED_PATHS.MFA_VERIFY) {
+      const signinUrl = req.nextUrl.clone()
+      signinUrl.pathname = PUBLIC_PATHS.SIGNIN
+      return await deleteTokenFromCookie(NextResponse.redirect(signinUrl))
     }
   }
 
@@ -81,4 +76,25 @@ export const config = {
   matcher: [
     '/((?!api|_next/static|_next/image|favicon.ico|\\.well-known|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)',
   ],
+}
+
+// 認証ユーザーが適切なセッション情報を保持してるかチェック
+const hasValidSession = async (
+  client: SupabaseClient,
+  session: Session,
+): Promise<boolean> => {
+  const { data: user, error: getUserError } = await client.auth.getUser(
+    session.access_token,
+  )
+  if (getUserError) {
+    console.warn('fail get user:', getUserError)
+    return false
+  }
+  if (user.user) {
+    const { valid } = await checkValidSessionLevel(user.user, client)
+
+    return valid ?? false
+  }
+
+  return false
 }


### PR DESCRIPTION
このプルリクエストでは、ログインフローにおける多要素認証（MFA）の強制適用を導入します。主な変更点は以下の通りです：認証後に検証済みのMFA要因を持つユーザーを専用の検証ページにリダイレクトする機能の追加、MFA検証UIのサーバーサイドレンダリングの追加、およびユーザーが保護されたルートにアクセスする前にMFAを完了するようにミドルウェアを更新する機能の追加。

**MFA強制適用とルーティング:**

* OAuth認証後、検証済みのMFA要因を持つユーザーは、追加の検証を行うための新しい`MFA_VERIFY`ルートにリダイレクトされます（`frontend/src/app/api/auth/callback/route.ts`、`frontend/src/lib/constants/routes.ts`）。[[1]](diffhunk://#diff-f526786c686f2bb85f7cf733db6b10b5f3f0545fe6fac51676594e4297d4ed7aL4-R25) [[2]](diffhunk://# diff-5a22511851a170fef494f140768249a4f25ee4370df94d7056130271541e52faR18)
* サーバーサイドでレンダリングされる新しいページ `MfaVerifyPage` が、MFA 検証 UI を表示し、ユーザーに適した MFA 要因を選択します（`frontend/src/app/(auth)/mfa-verify/page.tsx`）。

**ミドルウェアとセッション検証:**

* ミドルウェアのロジックをリファクタリングし、新しいヘルパー関数 `hasValidSession` を使用して有効な MFA セッションレベルを確認します。有効な MFA セッションを持たないユーザーはサインイン画面にリダイレクトされますが、MFA 検証ページにアクセスする場合を除きます（`frontend/src/middleware.ts`）。[[1]](diffhunk://#diff-c97d84b7bce6d5239ff87ac5694ad83d8aee62fcb23fbf6870be5bd08a5222acL50-L63) [[2]](diffhunk://# diff-c97d84b7bce6d5239ff87ac5694ad83d8aee62fcb23fbf6870be5bd08a5222acR80-R100)
* `Session` と `SupabaseClient` のインポートが追加され、新しいセッション検証ロジックをサポートするようにしました（`frontend/src/middleware.ts`）。