### PR TITLE
fix: プルリクエストのトリガー設定をコメントアウト

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,8 +8,8 @@ on:
       - stage
       - develop
       - feat-**
-  pull_request:
-    branches: [main, prod, stage]
+  # pull_request:
+  #   branches: [main, prod, stage]
 
 permissions:
   id-token: write # OIDCトークン取得を許可


### PR DESCRIPTION
このプルリクエストは、GitHub Actions ワークフローの `pull_request` トリガーをコメントアウトすることで、デプロイメント ワークフローの構成に小さな変更を加えます。これにより、指定されたブランチを対象としたプルリクエストに対して、ワークフローが自動的に実行されなくなります。