### PR TITLE
`main`、`prod`、および `stage` ブランチをターゲットとするプルリクエストに対するワークフローのトリガーを無効化

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,8 +8,8 @@ on:
       - stage
       - develop
       - feat-**
-  pull_request:
-    branches: [main, prod, stage]
+  # pull_request:
+  #   branches: [main, prod, stage]
 
 permissions:
   id-token: write # OIDCトークン取得を許可


### PR DESCRIPTION
このプルリクエストは、デプロイメントワークフローの構成に小さな更新を加えます。この変更では、`.github/workflows/deployment.yml` ファイルの対応するセクションをコメントアウトすることで、`main`、`prod`、および `stage` ブランチをターゲットとするプルリクエストに対するワークフローのトリガーを無効化します。