### PR TITLE
AIによる演習生成、シード管理、LLM（大規模言語モデル）追跡をサポートするため、複数の新しいデータベーステーブルと列挙型を導入

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "cSpell.words": ["descope", "lhci", "magiclink", "MAILPIT", "vercel"],
+  "cSpell.words": ["descope", "lhci", "llms", "magiclink", "MAILPIT", "vercel"],
   "github.copilot.advanced": {},
   "github.copilot.chat.agent.runTasks": false,
   "deno.enable": true,

--- a/frontend/src/lib/supabase/schema/schema.ts
+++ b/frontend/src/lib/supabase/schema/schema.ts
@@ -274,6 +274,51 @@ export type Database = {
           },
         ]
       }
+      oauth_clients: {
+        Row: {
+          client_id: string
+          client_name: string | null
+          client_secret_hash: string
+          client_uri: string | null
+          created_at: string
+          deleted_at: string | null
+          grant_types: string
+          id: string
+          logo_uri: string | null
+          redirect_uris: string
+          registration_type: Database["auth"]["Enums"]["oauth_registration_type"]
+          updated_at: string
+        }
+        Insert: {
+          client_id: string
+          client_name?: string | null
+          client_secret_hash: string
+          client_uri?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          grant_types: string
+          id: string
+          logo_uri?: string | null
+          redirect_uris: string
+          registration_type: Database["auth"]["Enums"]["oauth_registration_type"]
+          updated_at?: string
+        }
+        Update: {
+          client_id?: string
+          client_name?: string | null
+          client_secret_hash?: string
+          client_uri?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          grant_types?: string
+          id?: string
+          logo_uri?: string | null
+          redirect_uris?: string
+          registration_type?: Database["auth"]["Enums"]["oauth_registration_type"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
       one_time_tokens: {
         Row: {
           created_at: string
@@ -707,6 +752,7 @@ export type Database = {
       code_challenge_method: "s256" | "plain"
       factor_status: "unverified" | "verified"
       factor_type: "totp" | "webauthn" | "phone"
+      oauth_registration_type: "dynamic" | "manual"
       one_time_token_type:
         | "confirmation_token"
         | "reauthentication_token"
@@ -738,6 +784,59 @@ export type Database = {
   }
   public: {
     Tables: {
+      exercise_generator_seeds: {
+        Row: {
+          created_at: string
+          fingerprint_sha256: string | null
+          generator_profile_id: string
+          id: string
+          idempotency_key: string | null
+          locale: string | null
+          meta: Json
+          raw_text: string | null
+          status: Database["public"]["Enums"]["seed_status"]
+          summary: string | null
+          title: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          fingerprint_sha256?: string | null
+          generator_profile_id: string
+          id?: string
+          idempotency_key?: string | null
+          locale?: string | null
+          meta?: Json
+          raw_text?: string | null
+          status?: Database["public"]["Enums"]["seed_status"]
+          summary?: string | null
+          title?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          fingerprint_sha256?: string | null
+          generator_profile_id?: string
+          id?: string
+          idempotency_key?: string | null
+          locale?: string | null
+          meta?: Json
+          raw_text?: string | null
+          status?: Database["public"]["Enums"]["seed_status"]
+          summary?: string | null
+          title?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "exercise_generator_seeds_generator_profile_id_fkey"
+            columns: ["generator_profile_id"]
+            isOneToOne: false
+            referencedRelation: "seed_generator_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       exercises: {
         Row: {
           create_type: Database["public"]["Enums"]["create_type"]
@@ -813,6 +912,99 @@ export type Database = {
         }
         Relationships: []
       }
+      llms: {
+        Row: {
+          created_at: string
+          id: string
+          is_active: boolean
+          meta: Json
+          model: string
+          updated_at: string
+          vendor: Database["public"]["Enums"]["llm_vendor"]
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          meta?: Json
+          model: string
+          updated_at?: string
+          vendor: Database["public"]["Enums"]["llm_vendor"]
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          meta?: Json
+          model?: string
+          updated_at?: string
+          vendor?: Database["public"]["Enums"]["llm_vendor"]
+        }
+        Relationships: []
+      }
+      seed_generator_profiles: {
+        Row: {
+          config: Json
+          created_at: string
+          description: string | null
+          id: string
+          is_active: boolean
+          meta: Json
+          name: string
+          profile_type: Database["public"]["Enums"]["seed_profile_type"]
+          updated_at: string
+        }
+        Insert: {
+          config?: Json
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          meta?: Json
+          name: string
+          profile_type: Database["public"]["Enums"]["seed_profile_type"]
+          updated_at?: string
+        }
+        Update: {
+          config?: Json
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          meta?: Json
+          name?: string
+          profile_type?: Database["public"]["Enums"]["seed_profile_type"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      seed_generator_themes: {
+        Row: {
+          created_at: string
+          description: string | null
+          id: string
+          is_active: boolean
+          title: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          title?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          title?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
       user_profiles: {
         Row: {
           avatar_url: string | null
@@ -877,6 +1069,9 @@ export type Database = {
       create_type: "system" | "user" | "admin" | "import"
       exercise_status: "draft" | "ready" | "hidden"
       exercise_type: "summary" | "explain" | "rewrite"
+      llm_vendor: "openai" | "google" | "anthropic"
+      seed_profile_type: "ai_theme" | "youtube_channels" | "web" | "storage"
+      seed_status: "active" | "paused" | "archived"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1451,6 +1646,7 @@ export const Constants = {
       code_challenge_method: ["s256", "plain"],
       factor_status: ["unverified", "verified"],
       factor_type: ["totp", "webauthn", "phone"],
+      oauth_registration_type: ["dynamic", "manual"],
       one_time_token_type: [
         "confirmation_token",
         "reauthentication_token",
@@ -1469,6 +1665,9 @@ export const Constants = {
       create_type: ["system", "user", "admin", "import"],
       exercise_status: ["draft", "ready", "hidden"],
       exercise_type: ["summary", "explain", "rewrite"],
+      llm_vendor: ["openai", "google", "anthropic"],
+      seed_profile_type: ["ai_theme", "youtube_channels", "web", "storage"],
+      seed_status: ["active", "paused", "archived"],
     },
   },
   storage: {

--- a/frontend/supabase/functions/_shared/openai/functions/generate_seed.ts
+++ b/frontend/supabase/functions/_shared/openai/functions/generate_seed.ts
@@ -1,0 +1,107 @@
+import { openai } from '../openai_client.ts'
+import { z } from 'https://esm.sh/zod@3.23.8'
+
+export const generateSeedData = z
+  .object({
+    title: z.string().min(1).max(30),
+    difficulty: z.coerce.number().int().min(1).max(5),
+    description: z.string().max(150),
+    body: z.string(),
+  })
+  .strict()
+export type GenerateSeedData = z.infer<typeof generateSeedData>
+
+type GenerateSeedParams = {
+  title: string
+  description: string
+  model: string
+  additionalPrompt?: {
+    user?: string
+    system?: string
+    minChars?: number
+    maxChars?: number
+    temperature?: number
+  }
+}
+type GenerateSeedResponse =
+  | {
+      success: true
+      data: GenerateSeedData
+      error?: never
+    }
+  | {
+      success: false
+      data?: never
+      error: string
+    }
+export const generateSeed = async (
+  params: GenerateSeedParams,
+): Promise<GenerateSeedResponse> => {
+  const { title, description, model, additionalPrompt } = params
+  const topic = [title, description].join('\n')
+
+  const system = [
+    'あなたは日本語の教材作成者です',
+    '必ず JSON オブジェクトのみを返してください',
+    `出力スキーマは: {
+        "title": "string",
+        "difficulty": 1|2|3|4|5,
+        "description": "string",
+        "body": "string",
+        }`,
+    'bodyは必ず topic に関連するものにしてください',
+    `bodyは最小${additionalPrompt?.minChars ?? 300}文字、最大${additionalPrompt?.maxChars ?? 1000}文字`,
+    'titleとdescriptionは生成したbodyに関連するものにしてください',
+    'titleは最大30文字',
+    'descriptionは最大150文字',
+    'difficultyは数値で、文章長さや、テーマの難しさの観点から1〜5で設定',
+    "禁止事項: 抽象的・汎用的なタイトル（例: '文書要約' '技術解説' 'リライト課題' など）。",
+  ]
+  if (additionalPrompt?.system) {
+    system.push(additionalPrompt.system)
+  }
+
+  const user = [`topic: ${topic}`]
+  if (additionalPrompt?.user) {
+    user.push(additionalPrompt.user)
+  }
+
+  const res = await openai.chat.completions.create({
+    model: model,
+    response_format: { type: 'json_object' },
+    temperature: additionalPrompt?.temperature ?? 0.5,
+    max_tokens: 1000,
+    messages: [
+      // AIに全体的な指示や役割、振る舞いを伝えるため
+      { role: 'system', content: system.join('\n') },
+      // ユーザーからの質問や命令を表現
+      { role: 'user', content: user.join('\n') },
+    ],
+  })
+
+  const content = res.choices?.[0]?.message?.content
+  if (!content) throw new Error('OpenAI returned no content')
+
+  let json: unknown
+  try {
+    json = JSON.parse(content)
+  } catch {
+    return { success: false, error: 'Invalid JSON from OpenAI' }
+  }
+
+  const { data, error, success } = generateSeedData.safeParse(json)
+  if (!success) {
+    const msg = error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')
+
+    return { success: false, error: `schema validation failed: ${msg}` }
+  }
+
+  const g: GenerateSeedData = {
+    title: data.title,
+    difficulty: data.difficulty,
+    description: data.description,
+    body: data.body,
+  }
+
+  return { success: true, data: g }
+}

--- a/frontend/supabase/functions/_shared/types/database.ts
+++ b/frontend/supabase/functions/_shared/types/database.ts
@@ -274,6 +274,51 @@ export type Database = {
           },
         ]
       }
+      oauth_clients: {
+        Row: {
+          client_id: string
+          client_name: string | null
+          client_secret_hash: string
+          client_uri: string | null
+          created_at: string
+          deleted_at: string | null
+          grant_types: string
+          id: string
+          logo_uri: string | null
+          redirect_uris: string
+          registration_type: Database["auth"]["Enums"]["oauth_registration_type"]
+          updated_at: string
+        }
+        Insert: {
+          client_id: string
+          client_name?: string | null
+          client_secret_hash: string
+          client_uri?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          grant_types: string
+          id: string
+          logo_uri?: string | null
+          redirect_uris: string
+          registration_type: Database["auth"]["Enums"]["oauth_registration_type"]
+          updated_at?: string
+        }
+        Update: {
+          client_id?: string
+          client_name?: string | null
+          client_secret_hash?: string
+          client_uri?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          grant_types?: string
+          id?: string
+          logo_uri?: string | null
+          redirect_uris?: string
+          registration_type?: Database["auth"]["Enums"]["oauth_registration_type"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
       one_time_tokens: {
         Row: {
           created_at: string
@@ -707,6 +752,7 @@ export type Database = {
       code_challenge_method: "s256" | "plain"
       factor_status: "unverified" | "verified"
       factor_type: "totp" | "webauthn" | "phone"
+      oauth_registration_type: "dynamic" | "manual"
       one_time_token_type:
         | "confirmation_token"
         | "reauthentication_token"
@@ -738,6 +784,59 @@ export type Database = {
   }
   public: {
     Tables: {
+      exercise_generator_seeds: {
+        Row: {
+          created_at: string
+          fingerprint_sha256: string | null
+          generator_profile_id: string
+          id: string
+          idempotency_key: string | null
+          locale: string | null
+          meta: Json
+          raw_text: string | null
+          status: Database["public"]["Enums"]["seed_status"]
+          summary: string | null
+          title: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          fingerprint_sha256?: string | null
+          generator_profile_id: string
+          id?: string
+          idempotency_key?: string | null
+          locale?: string | null
+          meta?: Json
+          raw_text?: string | null
+          status?: Database["public"]["Enums"]["seed_status"]
+          summary?: string | null
+          title?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          fingerprint_sha256?: string | null
+          generator_profile_id?: string
+          id?: string
+          idempotency_key?: string | null
+          locale?: string | null
+          meta?: Json
+          raw_text?: string | null
+          status?: Database["public"]["Enums"]["seed_status"]
+          summary?: string | null
+          title?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "exercise_generator_seeds_generator_profile_id_fkey"
+            columns: ["generator_profile_id"]
+            isOneToOne: false
+            referencedRelation: "seed_generator_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       exercises: {
         Row: {
           create_type: Database["public"]["Enums"]["create_type"]
@@ -813,6 +912,99 @@ export type Database = {
         }
         Relationships: []
       }
+      llms: {
+        Row: {
+          created_at: string
+          id: string
+          is_active: boolean
+          meta: Json
+          model: string
+          updated_at: string
+          vendor: Database["public"]["Enums"]["llm_vendor"]
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          meta?: Json
+          model: string
+          updated_at?: string
+          vendor: Database["public"]["Enums"]["llm_vendor"]
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          meta?: Json
+          model?: string
+          updated_at?: string
+          vendor?: Database["public"]["Enums"]["llm_vendor"]
+        }
+        Relationships: []
+      }
+      seed_generator_profiles: {
+        Row: {
+          config: Json
+          created_at: string
+          description: string | null
+          id: string
+          is_active: boolean
+          meta: Json
+          name: string
+          profile_type: Database["public"]["Enums"]["seed_profile_type"]
+          updated_at: string
+        }
+        Insert: {
+          config?: Json
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          meta?: Json
+          name: string
+          profile_type: Database["public"]["Enums"]["seed_profile_type"]
+          updated_at?: string
+        }
+        Update: {
+          config?: Json
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          meta?: Json
+          name?: string
+          profile_type?: Database["public"]["Enums"]["seed_profile_type"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      seed_generator_themes: {
+        Row: {
+          created_at: string
+          description: string | null
+          id: string
+          is_active: boolean
+          title: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          title?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          title?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
       user_profiles: {
         Row: {
           avatar_url: string | null
@@ -877,6 +1069,9 @@ export type Database = {
       create_type: "system" | "user" | "admin" | "import"
       exercise_status: "draft" | "ready" | "hidden"
       exercise_type: "summary" | "explain" | "rewrite"
+      llm_vendor: "openai" | "google" | "anthropic"
+      seed_profile_type: "ai_theme" | "youtube_channels" | "web" | "storage"
+      seed_status: "active" | "paused" | "archived"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1451,6 +1646,7 @@ export const Constants = {
       code_challenge_method: ["s256", "plain"],
       factor_status: ["unverified", "verified"],
       factor_type: ["totp", "webauthn", "phone"],
+      oauth_registration_type: ["dynamic", "manual"],
       one_time_token_type: [
         "confirmation_token",
         "reauthentication_token",
@@ -1469,6 +1665,9 @@ export const Constants = {
       create_type: ["system", "user", "admin", "import"],
       exercise_status: ["draft", "ready", "hidden"],
       exercise_type: ["summary", "explain", "rewrite"],
+      llm_vendor: ["openai", "google", "anthropic"],
+      seed_profile_type: ["ai_theme", "youtube_channels", "web", "storage"],
+      seed_status: ["active", "paused", "archived"],
     },
   },
   storage: {

--- a/frontend/supabase/functions/_shared/types/exercise_generator_seeds.ts
+++ b/frontend/supabase/functions/_shared/types/exercise_generator_seeds.ts
@@ -1,0 +1,8 @@
+import type { Database } from './database.ts'
+
+export type ExerciseGeneratorSeedsRow =
+  Database['public']['Tables']['exercise_generator_seeds']['Row']
+
+  export type ExerciseGeneratorSeedsInsertRow =
+  Database['public']['Tables']['exercise_generator_seeds']['Insert']
+

--- a/frontend/supabase/functions/deno.lock
+++ b/frontend/supabase/functions/deno.lock
@@ -1,24 +1,99 @@
 {
   "version": "5",
   "specifiers": {
+    "npm:@supabase/supabase-js@2": "2.57.2",
     "npm:@types/node@*": "24.2.0"
   },
   "npm": {
+    "@supabase/auth-js@2.71.1": {
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/functions-js@2.4.5": {
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/node-fetch@2.6.15": {
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "@supabase/postgrest-js@1.21.3": {
+      "integrity": "sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/realtime-js@2.15.5": {
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "dependencies": [
+        "@supabase/node-fetch",
+        "@types/phoenix",
+        "@types/ws",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.12.0": {
+      "integrity": "sha512-HdKq8jAARnZ/OokE0wml/KzLwJ1X/iX7GtfLvve1HHxxsB3Y0juk0+3dMKr0mKRpjiGzzgvHhF2hxt9ui17OUQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/supabase-js@2.57.2": {
+      "integrity": "sha512-MxaZqZKUPK1ExzOilgSZqCPCxVPjevUrh6bcWz1SrDZexFc9VJ2cJbVP1EG1hKQx/bfLdTUjIZMoIrYpYqAPYw==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/node-fetch",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
     "@types/node@24.2.0": {
       "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "dependencies": [
         "undici-types"
       ]
     },
+    "@types/phoenix@1.6.6": {
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "undici-types@7.10.0": {
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "ws@8.18.3": {
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="
     }
   },
   "redirects": {
     "https://esm.sh/@supabase/node-fetch@^2.6.13?target=denonext": "https://esm.sh/@supabase/node-fetch@2.6.15?target=denonext",
     "https://esm.sh/@supabase/node-fetch@^2.6.14?target=denonext": "https://esm.sh/@supabase/node-fetch@2.6.15?target=denonext",
     "https://esm.sh/@supabase/storage-js@^2.10.4?target=denonext": "https://esm.sh/@supabase/storage-js@2.11.0?target=denonext",
-    "https://esm.sh/@supabase/supabase-js@2": "https://esm.sh/@supabase/supabase-js@2.56.1",
     "https://esm.sh/tr46@~0.0.3?target=denonext": "https://esm.sh/tr46@0.0.3?target=denonext",
     "https://esm.sh/webidl-conversions@^3.0.0?target=denonext": "https://esm.sh/webidl-conversions@3.0.1?target=denonext",
     "https://esm.sh/whatwg-url@^5.0.0?target=denonext": "https://esm.sh/whatwg-url@5.0.0?target=denonext"
@@ -32,8 +107,8 @@
     "https://esm.sh/@supabase/realtime-js@2.15.4/denonext/realtime-js.mjs": "014803e3c1776dfe9c0c05c4f890252c66afce791fe1d93ecf687d7e773febcc",
     "https://esm.sh/@supabase/storage-js@2.11.0/denonext/storage-js.mjs": "86f098636aef56302e6a7389b8eba859874180b0857661be196c3cce387b6461",
     "https://esm.sh/@supabase/storage-js@2.11.0?target=denonext": "d7e8b6651554f79445c88d1beaa8c5e2fcb960a6f67449e4903f532ea3301539",
-    "https://esm.sh/@supabase/supabase-js@2.56.1": "5cc7adee6789b3c1bd9959694ee1564da6005b87ef7bae8fd4e595e5959a5ccd",
-    "https://esm.sh/@supabase/supabase-js@2.56.1/denonext/supabase-js.mjs": "5b73fda4c976f0061ce33ba4f403bbb03a254304d93a4eb610d1a27d10404675",
+    "https://esm.sh/@supabase/supabase-js@2.56.1/denonext/dist/module/SupabaseClient.mjs": "b4bfe316075d2adf4962fe3f03253b7b2c9d5d940ce3979374b1510237704c74",
+    "https://esm.sh/@supabase/supabase-js@2.56.1/dist/module/SupabaseClient.js": "802fc5068c169ac5524baee081e8506d11c61843480b3aa7bda35b942c39672f",
     "https://esm.sh/openai@4.55.3": "b8d2b2f0709fd3f831311300c53d1fd00476e0e30be0ef190e0feabcc9adc849",
     "https://esm.sh/openai@4.55.3/denonext/_shims/MultipartBody.mjs": "f4357bfacbf3392e64df1a51c6b6947a562ef3dda8be1709089b57f00e15dc37",
     "https://esm.sh/openai@4.55.3/denonext/_shims/auto/runtime.mjs": "72dd87ff55cd0917716cfa5114f5e0186e6f83faa1ea91abdd2e87d16576db61",
@@ -91,12 +166,13 @@
     "https://esm.sh/openai@4.55.3/denonext/streaming.mjs": "1b6fcdff353d13ce3dfcb3c4eb26bde14fba08b5884e841b1792c1c2fa459d72",
     "https://esm.sh/openai@4.55.3/denonext/uploads.mjs": "059505256ebdea55ba253e302071420c6a7601efd1c3a870beb854c827fbf95e",
     "https://esm.sh/openai@4.55.3/denonext/version.mjs": "f58aee53671a291a17a018b46a5b0b443a9567dd40201d397b52d7ed7715c910",
-    "https://esm.sh/openai@4.55.3/index.js": "b0660aac070234a66f6cbf34e630b630e4f90bf4cd3e67f6bb8f2ed270e2e74e",
     "https://esm.sh/tr46@0.0.3/denonext/tr46.mjs": "5753ec0a99414f4055f0c1f97691100f13d88e48a8443b00aebb90a512785fa2",
     "https://esm.sh/tr46@0.0.3?target=denonext": "19cb9be0f0d418a0c3abb81f2df31f080e9540a04e43b0f699bce1149cba0cbb",
     "https://esm.sh/webidl-conversions@3.0.1/denonext/webidl-conversions.mjs": "54b5c2d50a294853c4ccebf9d5ed8988c94f4e24e463d84ec859a866ea5fafec",
     "https://esm.sh/webidl-conversions@3.0.1?target=denonext": "4e20318d50528084616c79d7b3f6e7f0fe7b6d09013bd01b3974d7448d767e29",
     "https://esm.sh/whatwg-url@5.0.0/denonext/whatwg-url.mjs": "29b16d74ee72624c915745bbd25b617cfd2248c6af0f5120d131e232a9a9af79",
-    "https://esm.sh/whatwg-url@5.0.0?target=denonext": "f001a2cadf81312d214ca330033f474e74d81a003e21e8c5d70a1f46dc97b02d"
+    "https://esm.sh/whatwg-url@5.0.0?target=denonext": "f001a2cadf81312d214ca330033f474e74d81a003e21e8c5d70a1f46dc97b02d",
+    "https://esm.sh/zod@3.23.8": "15e60c792ac21d4818f181671c7c74bf33bf7526d487dc524911e42785d8b5c2",
+    "https://esm.sh/zod@3.23.8/denonext/zod.mjs": "0776ff1b85cde578a80a14b7921d72dbf17ba4de827f5ddf9c3423d7ab8562cf"
   }
 }

--- a/frontend/supabase/functions/generate_exersice_seeds/.npmrc
+++ b/frontend/supabase/functions/generate_exersice_seeds/.npmrc
@@ -1,0 +1,3 @@
+# Configuration for private npm package dependencies
+# For more information on using private registries with Edge Functions, see:
+# https://supabase.com/docs/guides/functions/import-maps#importing-from-private-registries

--- a/frontend/supabase/functions/generate_exersice_seeds/_shared/seed_generator.ts
+++ b/frontend/supabase/functions/generate_exersice_seeds/_shared/seed_generator.ts
@@ -1,0 +1,170 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '../../_shared/types/database.ts'
+import { z } from 'https://esm.sh/zod@3.23.8'
+import { generateSeed } from '../../_shared/openai/functions/generate_seed.ts'
+import { ExerciseGeneratorSeedsInsertRow } from '../../_shared/types/exercise_generator_seeds.ts'
+
+type GenerateSeedResult = {
+  locale: string
+  title: string
+  summary: string
+  rawText: string
+}
+
+type GenerateExerciseSeedParams = {
+  client: SupabaseClient<Database>
+  profileId: string
+  seedData: GenerateSeedResult
+}
+type GenerateExerciseSeedResponse =
+  | {
+      success: true
+      data: { seed_id: string }
+      error?: never
+    }
+  | {
+      success: false
+      data?: never
+      error: string
+    }
+export const generateExerciseSeed = async (
+  params: GenerateExerciseSeedParams,
+): Promise<GenerateExerciseSeedResponse> => {
+  const { client, profileId, seedData } = params
+
+  const row: ExerciseGeneratorSeedsInsertRow = {
+    status: 'active',
+    generator_profile_id: profileId,
+    title: seedData.title,
+    summary: seedData.summary,
+    raw_text: seedData.rawText,
+  }
+
+  const { data, error } = await client
+    .from('exercise_generator_seeds')
+    .insert(row)
+    .select('id')
+    .single()
+  if (error) {
+    return {
+      success: false,
+      error: `${error.code} : ${error.message}`,
+    }
+  }
+
+  return {
+    success: true,
+    data: { seed_id: data.id },
+  }
+}
+
+export const generateSeedFromThemeConfigSchema = z.object({
+  theme_id: z.string().uuid(),
+  llm_id: z.string().uuid(),
+  prompt: z
+    .object({
+      user: z.string().optional(),
+      system: z.string().optional(),
+      min_chars: z.number().optional(),
+      max_chars: z.number().optional(),
+    })
+    .optional(),
+})
+type GenerateSeedFromThemeConfig = z.infer<typeof generateSeedFromThemeConfigSchema>
+
+type GenerateSeedFromThemeParams = {
+  client: SupabaseClient<Database>
+  config: GenerateSeedFromThemeConfig
+}
+
+type GenerateSeedFromThemeResponse =
+  | {
+      success: true
+      data: GenerateSeedResult
+      error?: never
+    }
+  | {
+      success: false
+      data?: never
+      error: string
+    }
+
+export const generateSeedFromTheme = async (
+  params: GenerateSeedFromThemeParams,
+): Promise<GenerateSeedFromThemeResponse> => {
+  const { client, config } = params
+  const { theme_id, llm_id } = config
+
+  const { data: theme, error: fetchThemeError } = await client
+    .from('seed_generator_themes')
+    .select('*')
+    .eq('id', theme_id)
+    .eq('is_active', true)
+    .single()
+  if (fetchThemeError) {
+    return {
+      success: false,
+      error: `${fetchThemeError.name}: ${fetchThemeError.message}`,
+    }
+  }
+  if (!theme) {
+    return {
+      success: false,
+      error: 'not found theme from seed_generator_themes',
+    }
+  }
+
+  const { data: llm, error: fetchLlmError } = await client
+    .from('llms')
+    .select('*')
+    .eq('id', llm_id)
+    .eq('is_active', true)
+    .single()
+  if (fetchLlmError) {
+    return {
+      success: false,
+      error: `${fetchLlmError.name}: ${fetchLlmError.message}`,
+    }
+  }
+  if (!llm) {
+    return {
+      success: false,
+      error: 'not found theme from seed_generator_themes',
+    }
+  }
+
+  const { title, description } = theme
+  const { vendor, model } = llm
+
+  switch (vendor) {
+    case 'openai': {
+      const { success, data, error } = await generateSeed({
+        title: title ?? '',
+        description: description ?? '',
+        model,
+      })
+      if (!success) {
+        return {
+          success: false,
+          error,
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          locale: 'ja_JP',
+          title: data.title,
+          summary: data.description,
+          rawText: data.body,
+        },
+      }
+    }
+
+    default:
+      return {
+        success: false,
+        error: `unsupported vendor: ${vendor}`,
+      }
+  }
+}

--- a/frontend/supabase/functions/generate_exersice_seeds/index.ts
+++ b/frontend/supabase/functions/generate_exersice_seeds/index.ts
@@ -1,0 +1,100 @@
+import { createClient } from '@supabase/supabase-js'
+import { z } from 'https://esm.sh/zod@3.23.8'
+import type { Database } from '../_shared/types/database.ts'
+import {
+  generateExerciseSeed,
+  generateSeedFromTheme,
+  generateSeedFromThemeConfigSchema,
+} from './_shared/seed_generator.ts'
+import { jsonErr, jsonOk } from '../_shared/http/http.ts'
+
+// ---- env
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+const CRON_SECRET = Deno.env.get('CRON_SECRET')
+const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+const reqSchema = z.object({
+  profile_id: z.string().uuid(),
+})
+
+Deno.serve(async (req) => {
+  try {
+    if (CRON_SECRET) {
+      const given = req.headers.get('x-cron-secret')
+      if (given !== CRON_SECRET)
+        return new Response(JSON.stringify({ ok: false, error: 'unauthorized' }), {
+          status: 401,
+        })
+    }
+
+    console.log('req: ', req)
+    const body = await req
+      .json()
+      .catch(() => console.error('fail to json from request', req))
+    const {
+      success: parseSuccess,
+      data: parseData,
+      error: parseError,
+    } = reqSchema.safeParse(body)
+    if (!parseSuccess) {
+      return jsonErr({ ok: false, error: String(parseError) }, 400)
+    }
+    const { profile_id } = parseData
+
+    // プロファイル取得
+    const { data: profile, error: pErr } = await supabase
+      .from('seed_generator_profiles')
+      .select('*')
+      .eq('id', profile_id)
+      .single()
+    if (pErr || !profile) throw new Error('profile not found')
+    if (!profile.is_active) throw new Error('profile is not active')
+
+    const { profile_type, config } = profile
+
+    switch (profile_type) {
+      case 'ai_theme': {
+        const {
+          success: parseSuccess,
+          data: parseData,
+          error: parseError,
+        } = generateSeedFromThemeConfigSchema.safeParse(config)
+        if (!parseSuccess) {
+          throw new Error('invalid config of ai_theme', parseError)
+        }
+
+        const {
+          success: seedSuccess,
+          data: seedData,
+          error: seedError,
+        } = await generateSeedFromTheme({ client: supabase, config: parseData })
+        if (!seedSuccess) {
+          throw new Error(`fail generate seed data from theme: ${seedError}`)
+        }
+
+        const {
+          success: generateSuccess,
+          data: generateData,
+          error: generateError,
+        } = await generateExerciseSeed({
+          client: supabase,
+          profileId: profile_id,
+          seedData,
+        })
+        if (!generateSuccess) {
+          throw new Error(`fail generate exercise seed: ${generateError}`)
+        }
+
+        return jsonOk({ ok: true, seed_id: generateData.seed_id })
+      }
+
+      default:
+        console.log('wip')
+        return jsonOk({ ok: true, seed_id: null })
+    }
+  } catch (e) {
+    console.error('unexpected error', e)
+    return jsonErr({ ok: false, error: String(e) }, 500)
+  }
+})

--- a/frontend/supabase/migrations/20250907145349_llms.sql
+++ b/frontend/supabase/migrations/20250907145349_llms.sql
@@ -1,0 +1,42 @@
+-- LLMs table
+-- 目的: 利用可能なLLMカタログ（ベンダ名とモデル名）。秘密情報は保存しない。
+
+-- 共通: updated_at を自動更新するトリガ関数（他テーブルでも使えます）
+create or replace function public.trigger_set_timestamp()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end
+$$;
+
+-- 1) ベンダ enum
+do $$ begin
+  create type llm_vendor as enum ('openai','google','anthropic');
+exception when duplicate_object then null; end $$;
+
+-- テーブル本体
+create table if not exists public.llms (
+  id         uuid primary key default gen_random_uuid(),
+  vendor     llm_vendor not null,         -- 例: 'openai'
+  model      text not null,               -- 例: 'gpt-4o-mini'（モデル識別子）
+  is_active  boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  meta       jsonb not null default '{}'::jsonb  -- 任意メタ（備考・表示名など）
+);
+
+-- updated_at 自動更新トリガ
+drop trigger if exists trg_llms_updated_at on public.llms;
+create trigger trg_llms_updated_at
+  before update on public.llms
+  for each row execute function public.trigger_set_timestamp();
+
+-- RLS 有効化
+alter table public.llms enable row level security;
+
+-- 念のため、匿名/認証ユーザーのテーブル権限を明示的に剥奪
+revoke all on table public.llms from anon;
+revoke all on table public.llms from authenticated;

--- a/frontend/supabase/migrations/20250907153857_seed_generator_profiles.sql
+++ b/frontend/supabase/migrations/20250907153857_seed_generator_profiles.sql
@@ -1,0 +1,57 @@
+-- 目的: seed生成方針のプロファイル（ai_theme / youtube_channels など）
+
+-- UUID
+create extension if not exists pgcrypto;
+
+-- プロファイル種別
+do $$ begin
+  create type seed_profile_type as enum ('ai_theme','youtube_channels','web','storage');
+exception when duplicate_object then null; end $$;
+
+-- updated_at 自動更新
+create or replace function public.trigger_set_timestamp()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end$$;
+
+-- 本体
+create table if not exists public.seed_generator_profiles (
+  id               uuid primary key default gen_random_uuid(),
+  name             text not null,
+  description      text,
+
+  profile_type     seed_profile_type not null,       -- 'ai_theme' | 'youtube_channels' | ...
+  is_active        boolean not null default true,
+
+  -- プロファイル固有設定（型ごとの期待例は下のコメント参照）
+  config           jsonb not null default '{}'::jsonb,
+  -- 例: ai_theme
+  -- { "llm_id":"<uuid or vendor+model>", "min_chars":800, "max_chars":1500,
+  --   "prompt_system":"...", "prompt_user":"..." }
+  -- 例: youtube_channels
+  -- { "min_duration_sec":180, "allow_shorts":false, "text_provider":"notebooklm|captions|asr" }
+
+  meta             jsonb not null default '{}'::jsonb,  -- 補助メタ（自由）
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);
+
+-- インデックス
+create index if not exists idx_sgp_active on public.seed_generator_profiles(is_active);
+create index if not exists idx_sgp_type   on public.seed_generator_profiles(profile_type);
+
+-- updated_at トリガ
+drop trigger if exists trg_sgp_updated_at on public.seed_generator_profiles;
+create trigger trg_sgp_updated_at
+  before update on public.seed_generator_profiles
+  for each row execute function public.trigger_set_timestamp();
+
+
+-- RLS 有効化
+alter table public.llms enable row level security;
+
+-- 念のため、匿名/認証ユーザーのテーブル権限を明示的に剥奪
+revoke all on table public.llms from anon;
+revoke all on table public.llms from authenticated;

--- a/frontend/supabase/migrations/20250907154602_seed_generator_profiles_fix_grant.sql
+++ b/frontend/supabase/migrations/20250907154602_seed_generator_profiles_fix_grant.sql
@@ -1,0 +1,8 @@
+
+
+-- RLS 有効化
+alter table public.seed_generator_profiles enable row level security;
+
+-- 念のため、匿名/認証ユーザーのテーブル権限を明示的に剥奪
+revoke all on table public.seed_generator_profiles from anon;
+revoke all on table public.seed_generator_profiles from authenticated;

--- a/frontend/supabase/migrations/20250907155301_exercise_generator_seeds.sql
+++ b/frontend/supabase/migrations/20250907155301_exercise_generator_seeds.sql
@@ -1,0 +1,64 @@
+-- 02_create_exercise_generator_seeds.sql
+-- 種データ本体（生成元プロファイルFK＋由来情報。assetテーブルは使いません）
+
+-- UUID 生成拡張（既に有効ならスキップ）
+create extension if not exists pgcrypto;
+
+-- 必要な enum（存在時はスキップ）
+do $$ begin
+  create type seed_status as enum ('active','paused','archived');
+exception when duplicate_object then null; end $$;
+
+-- updated_at 自動更新トリガ関数（共通で使い回し可）
+create or replace function public.trigger_set_timestamp()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end
+$$;
+
+-- 本体
+create table if not exists public.exercise_generator_seeds (
+  id                   uuid primary key default gen_random_uuid(),
+
+  -- どの seed_generator_profile（= ai_theme / youtube_channels 等）から生成されたか
+  generator_profile_id uuid not null
+    references public.seed_generator_profiles(id)
+    on delete restrict,
+
+  status               seed_status not null default 'active',
+  locale               text default 'ja-JP',
+
+  title                text,
+  summary              text,
+  raw_text             text,                           -- LLM入力用の正規化本文（抽出/ASR後）
+  meta                 jsonb not null default '{}'::jsonb,  -- {source_url, license, author ...}
+
+  -- 冪等化/重複排除
+  idempotency_key      text,                           -- 外部IDや (profile+外部ID) 等
+  fingerprint_sha256   text,                           -- 正規化本文のハッシュなど
+
+  created_at           timestamptz not null default now(),
+  updated_at           timestamptz not null default now()
+);
+
+-- インデックス
+create index if not exists idx_egs_generator_profile
+  on public.exercise_generator_seeds (generator_profile_id);
+
+-- updated_at 自動更新トリガ
+drop trigger if exists trg_egs_seeds_updated_at on public.exercise_generator_seeds;
+create trigger trg_egs_seeds_updated_at
+  before update on public.exercise_generator_seeds
+  for each row execute function public.trigger_set_timestamp();
+
+
+-- RLS 有効化
+alter table public.exercise_generator_seeds enable row level security;
+
+-- 念のため、匿名/認証ユーザーのテーブル権限を明示的に剥奪
+revoke all on table public.exercise_generator_seeds from anon;
+revoke all on table public.exercise_generator_seeds from authenticated;

--- a/frontend/supabase/migrations/20250908184305_seed_generator_themes.sql
+++ b/frontend/supabase/migrations/20250908184305_seed_generator_themes.sql
@@ -1,0 +1,42 @@
+-- 02_create_exercise_generator_seeds.sql
+-- 種データ本体（生成元プロファイルFK＋由来情報。assetテーブルは使いません）
+
+-- UUID 生成拡張（既に有効ならスキップ）
+create extension if not exists pgcrypto;
+
+-- updated_at 自動更新トリガ関数（共通で使い回し可）
+create or replace function public.trigger_set_timestamp()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end
+$$;
+
+-- 本体
+create table if not exists public.seed_generator_themes (
+  id                   uuid primary key default gen_random_uuid(),
+
+  title                text,
+  description          text,
+  is_active            boolean not null default true,
+
+  created_at           timestamptz not null default now(),
+  updated_at           timestamptz not null default now()
+);
+
+-- updated_at 自動更新トリガ
+drop trigger if exists trg_seed_generator_themes_updated_at on public.seed_generator_themes;
+create trigger trg_seed_generator_themes_updated_at
+  before update on public.seed_generator_themes
+  for each row execute function public.trigger_set_timestamp();
+
+
+-- RLS 有効化
+alter table public.seed_generator_themes enable row level security;
+
+-- 念のため、匿名/認証ユーザーのテーブル権限を明示的に剥奪
+revoke all on table public.seed_generator_themes from anon;
+revoke all on table public.seed_generator_themes from authenticated;


### PR DESCRIPTION
このプルリクエストでは、AIによる演習生成、シード管理、LLM（大規模言語モデル）追跡をサポートするため、複数の新しいデータベーステーブルと列挙型を導入します。また、OpenAIを使用した演習シードデータ生成ユーティリティを追加し、それに応じて型定義と定数を更新します。これらの変更は、アプリケーション内でスケーラブルかつ設定可能なAI生成コンテンツの基盤を構築します。

**データベーススキーマの拡張:**

* `public`スキーマに新規テーブルを追加: `exercise_generator_seeds`、`llms`、`seed_generator_profiles`、`seed_generator_themes`。AI生成エクササイズシード、LLM設定、シード生成プロファイル/テーマを管理するため。[[1]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR787-R839) [[2]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR915-R1007)
* 新しい列挙型を導入: `llm_vendor`、`seed_profile_type`、`seed_status`。これにより、新しいテーブルをサポートし、LLMベンダー、シードプロファイルタイプ、シードステータスに対する強い型付けを提供します。
* OAuthクライアント管理と登録タイプをサポートするため、`auth`スキーマに`oauth_clients`テーブルと`oauth_registration_type`列挙型を追加しました。[[1]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR277-R321) [[2]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR755)

**型定義と定数:**

* 新しいテーブルと列挙型を反映するため、`frontend/src/lib/supabase/schema/schema.ts` および `frontend/supabase/functions/_shared/types/database.ts` の両方で TypeScript データベース型と定数を更新しました。[[1]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR277-R321) [[2]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR755) [[3]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR787-R839) [[4]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR915-R1007) [[5]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR1072-R1074) [[6]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR1649) [[7]](diffhunk://# diff-a48d76a7d242686ee393127c48e863036b84d976a05f4fb1790a7d5395846dfeR1668-R1670)
* `exercise_generator_seeds` 行および挿入用の新しい型定義ファイルを追加。

**AIによるシード生成:**

* `generate_seed.ts` に `generateSeed` ユーティリティを実装。OpenAIを使用してプロンプトに基づく演習シードデータを生成し、出力スキーマを検証。

**その他:**

* VSCodeのcSpell辞書に「llms」を追加（.vscode/settings.json）
* Edge Functionsでプライベートnpmパッケージ依存関係を構成するための`.npmrc`ファイルテンプレートを追加。